### PR TITLE
Performance: Use Hash element assignment instead of merge!

### DIFF
--- a/lib/requisite/api_model.rb
+++ b/lib/requisite/api_model.rb
@@ -28,9 +28,9 @@ module Requisite
     def to_hash(show_nil: false)
       preprocess_model
       {}.tap do |result|
-        self.class.attribute_keys_with_inheritance.each do |meth|
-          value = self.send(meth)
-          result.merge!({meth => value}) if show_nil || !value.nil?
+        self.class.attribute_keys_with_inheritance.each do |key|
+          value = self.send(key)
+          result[key] = value if show_nil || !value.nil?
         end
       end
     end
@@ -88,17 +88,12 @@ module Requisite
       nil
     end
 
-
     def model_responds_to_attribute_query?(name)
       if @model.kind_of?(Hash)
         @model[name] != nil
       else
         @model.send(name) if @model.respond_to?(name)
       end
-    end
-
-    def merge_attribute_if_exists!(to_merge, attribute_name)
-      attribute_from_model(attribute_name) ? to_merge.merge!(attribute_from_model(attribute_name)) : to_merge
     end
 
     def preprocess_model


### PR DESCRIPTION
Minor performance improvements

https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code


<details>
<summary>benchmark.rb</summary>

```ruby
require 'benchmark'
require_relative './lib/requisite'

class SimpleResponse < Requisite::ApiModel
  serialized_attributes do
    attribute :id, stringify: true
    attribute :title
  end
end;

class ComplexResponse < Requisite::ApiModel
  serialized_attributes do
    attribute :a
    attribute :b
    attribute :c
    attribute :d
    attribute :e
    attribute :f
    attribute :g
    attribute :h
    attribute :i
    attribute :j
    attribute :k
    attribute :l
    attribute :m
    attribute :n
    attribute :o
    attribute :p
    attribute :q
    attribute :r
    attribute :s
    attribute :t
  end
end;

simple_model = {
  id: 123,
  title: 'This is the title'
};

complex_model = {
  a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10,
  k: 11, l: 12, m: 13, n: 14, o: 15, p: 16, q: 17, r: 18, s: 19, t: 20,
};

iterations = 200_000;

Benchmark.bm(22) do |bm|
  bm.report('simple response') do
    iterations.times do
      SimpleResponse.new(simple_model).to_hash(show_nil: true)
    end
  end

  bm.report('complex response') do
    iterations.times do
      ComplexResponse.new(complex_model).to_hash(show_nil: true)
    end
  end
end
```
</details>

---

**Before**:
```
➜  requisite git:(master) ✗ irb
irb(main):001:0> require_relative './benchmark.rb'
                             user     system      total        real
simple response          1.630000   0.040000   1.670000 (  2.137809)
complex response         8.640000   0.250000   8.890000 (  9.167891)
=> true
irb(main):002:0> exit
```
complex response consistently around 9-10 seconds for 200,000 iterations

**After**:
```
➜  requisite git:(master) ✗ git co sean/minor_performance_improvements
Switched to branch 'sean/minor_performance_improvements'
➜  requisite git:(sean/minor_performance_improvements) ✗ irb
irb(main):001:0> require_relative './benchmark.rb'
                             user     system      total        real
simple response          1.010000   0.010000   1.020000 (  1.042418)
complex response         6.190000   0.100000   6.290000 (  6.844974)
=> true
irb(main):002:0> exit
```
complex response consistently around 6-7 seconds for 200,000 iterations