### PR TITLE
update version and CHANGES to 0.4.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 ### Unreleased
+
+### 0.4.1 (6th February 2019)
   - Remove Gemfile.lock
 
 ### 0.3.0 (15th April 2015):

--- a/lib/requisite/version.rb
+++ b/lib/requisite/version.rb
@@ -1,3 +1,3 @@
 module Requisite
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
Going to push the 0.4.1 gem to rubygems, built and loads fine.

```
Raphs-MacBook-Pro:requisite raph$ gem install ./requisite-0.4.1.gem
Successfully installed requisite-0.4.1
Parsing documentation for requisite-0.4.1
Done installing documentation for requisite after 0 seconds
1 gem installed
Raphs-MacBook-Pro:requisite raph$ irb
irb(main):001:0> require 'requisite'
=> true
irb(main):002:0> Requisite::VERSION
=> "0.4.1"
irb(main):003:0> exit
```