### PR TITLE
Add around_each_attribute hook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class UserApiModel < Requisite::ApiModel
     attribute! :username
     attribute :real_name
   end
-  
+
   # method with the name of of an attribute will be called to calculate the mapped value
   def real_name
     "#{attribute_from_model(:first_name)} #{attribute_from_model(:last_name)}"
@@ -88,10 +88,10 @@ Example:
 class UserApiModel < Requisite::ApiModel
   serialized_attributes do
     attribute :id, stringify: true
-    attribute :custom_attributes, rename: :custom_data 
+    attribute :custom_attributes, rename: :custom_data
     attribute :is_awesome, default: true
     attribute :awesome_score, rename: :score, stringify: true, default: 9001
-    attribute :age, type: Fixnum,
+    attribute :age, type: Integer,
     attribute :tired, type: Requisite::Boolean
   end
 end
@@ -131,7 +131,7 @@ With typed hashes, only values specified with a type are permitted:
 ```ruby
 class UserApiModel < Requisite::ApiModel
   serialized_attributes do
-    attribute :data, typed_hash: { is_awesome: Requisite::Boolean, score: Fixnum, name: String  }
+    attribute :data, typed_hash: { is_awesome: Requisite::Boolean, score: Integer, name: String  }
   end
 end
 
@@ -198,7 +198,27 @@ class ApiUser < Requisite::ApiModel
     raise IdentifierNotFoundError unless identifier
   end
 end
-```  
+```
+
+#### Around each attribute
+
+An `around_each_attribute` method can be defined to wrap each attribute fetch in a block. This can be useful for instrumenting processing on a per attribute basis.
+
+```ruby
+class ApiUser < Requisite::ApiModel
+  serialized_attributes do
+    attribute :id, type: String
+    attribute :email, type: String
+  end
+
+  def around_each_attribute(name, &block)
+    start = Time.now
+    yield
+    end = Time.now
+    puts "Fetching #{name} took #{end - start}"
+  end
+end
+```
 
 #### Thanks
 

--- a/lib/requisite/boundary_object.rb
+++ b/lib/requisite/boundary_object.rb
@@ -4,14 +4,17 @@ module Requisite
       def attribute(name, options={})
         attribute_keys << name
         define_method(name) do
-          resolved_name = options[:rename] || name
-          result = self.send(:convert, resolved_name)
-          result = self.send(:parse_typed_hash, resolved_name, options[:typed_hash]) if options[:typed_hash]
-          result = self.send(:parse_scalar_hash, resolved_name) if options[:scalar_hash]
-          result = self.send(:parse_typed_array, resolved_name, options[:typed_array]) if options[:typed_array]
-          result = options[:default] if (options.key?(:default) && empty_result?(result))
-          raise_bad_type_if_type_mismatch(result, options[:type]) if options[:type] && result
-          result = result.to_s if options[:stringify]
+          result = nil
+          self.send(:around_each_attribute, name) do
+            resolved_name = options[:rename] || name
+            result = self.send(:convert, resolved_name)
+            result = self.send(:parse_typed_hash, resolved_name, options[:typed_hash]) if options[:typed_hash]
+            result = self.send(:parse_scalar_hash, resolved_name) if options[:scalar_hash]
+            result = self.send(:parse_typed_array, resolved_name, options[:typed_array]) if options[:typed_array]
+            result = options[:default] if (options.key?(:default) && empty_result?(result))
+            raise_bad_type_if_type_mismatch(result, options[:type]) if options[:type] && result
+            result = result.to_s if options[:stringify]
+          end
           result
         end
       end
@@ -19,13 +22,16 @@ module Requisite
       def attribute!(name, options={})
         attribute_keys << name
         define_method(name) do
-          resolved_name = options[:rename] || name
-          result = self.send(:convert!, resolved_name)
-          result = self.send(:parse_typed_hash, resolved_name, options[:typed_hash]) if options[:typed_hash]
-          result = self.send(:parse_scalar_hash, resolved_name) if options[:scalar_hash]
-          result = self.send(:parse_typed_array, resolved_name, options[:typed_array]) if options[:typed_array]
-          result = result.to_s if options[:stringify]
-          raise_bad_type_if_type_mismatch(result, options[:type]) if options[:type]
+          result = nil
+          self.send(:around_each_attribute, name) do
+            resolved_name = options[:rename] || name
+            result = self.send(:convert!, resolved_name)
+            result = self.send(:parse_typed_hash, resolved_name, options[:typed_hash]) if options[:typed_hash]
+            result = self.send(:parse_scalar_hash, resolved_name) if options[:scalar_hash]
+            result = self.send(:parse_typed_array, resolved_name, options[:typed_array]) if options[:typed_array]
+            result = result.to_s if options[:stringify]
+            raise_bad_type_if_type_mismatch(result, options[:type]) if options[:type]
+          end
           result
         end
       end
@@ -45,6 +51,10 @@ module Requisite
     end
 
     private
+
+    def around_each_attribute(name)
+      yield
+    end
 
     self.singleton_class.send(:alias_method, :a, :attribute)
     self.singleton_class.send(:alias_method, :a!, :attribute!)

--- a/test/requisite/api_model_test.rb
+++ b/test/requisite/api_model_test.rb
@@ -107,7 +107,7 @@ module Requisite
     end
 
     it 'attribute can be stringified after type check' do
-      DummyApiModel.serialized_attributes { attribute :num, stringify: true, type: Fixnum }
+      DummyApiModel.serialized_attributes { attribute :num, stringify: true, type: Integer }
       response = DummyApiModel.new(params_hash)
       _(response.to_hash).must_equal(:num => '12')
     end
@@ -202,7 +202,7 @@ module Requisite
 
       describe 'with typed arrays' do
         it 'allows arrays of one type' do
-          DummyApiModel.serialized_attributes { attribute :ids, typed_array: Fixnum }
+          DummyApiModel.serialized_attributes { attribute :ids, typed_array: Integer }
           response = DummyApiModel.new({ids: [1, 2, 3]})
           _(response.to_hash).must_equal(:ids => [1, 2, 3])
         end


### PR DESCRIPTION
This enables clients to add instrumentation or other functionality that has to run around each attribute generation.

I've also removed usages of `Fixnum` in the test suite, in order to make it compatible with ruby 3.