### PR TITLE
Instrument attributes correctly

### DIFF
--- a/lib/requisite/api_model.rb
+++ b/lib/requisite/api_model.rb
@@ -36,7 +36,10 @@ module Requisite
       preprocess_model
       {}.tap do |result|
         self.class.attribute_keys_with_inheritance.each do |key|
-          value = self.send(key)
+          value = nil
+          around_each_attribute(key) do
+            value = self.send(key)
+          end
           result[key] = value if show_nil || !value.nil?
         end
       end
@@ -105,6 +108,10 @@ module Requisite
 
     def preprocess_model
       # noop
+    end
+
+    def around_each_attribute(name)
+      yield
     end
   end
 end

--- a/lib/requisite/boundary_object.rb
+++ b/lib/requisite/boundary_object.rb
@@ -4,17 +4,14 @@ module Requisite
       def attribute(name, options={})
         attribute_keys << name
         define_method(name) do
-          result = nil
-          self.send(:around_each_attribute, name) do
-            resolved_name = options[:rename] || name
-            result = self.send(:convert, resolved_name)
-            result = self.send(:parse_typed_hash, resolved_name, options[:typed_hash]) if options[:typed_hash]
-            result = self.send(:parse_scalar_hash, resolved_name) if options[:scalar_hash]
-            result = self.send(:parse_typed_array, resolved_name, options[:typed_array]) if options[:typed_array]
-            result = options[:default] if (options.key?(:default) && empty_result?(result))
-            raise_bad_type_if_type_mismatch(result, options[:type]) if options[:type] && result
-            result = result.to_s if options[:stringify]
-          end
+          resolved_name = options[:rename] || name
+          result = self.send(:convert, resolved_name)
+          result = self.send(:parse_typed_hash, resolved_name, options[:typed_hash]) if options[:typed_hash]
+          result = self.send(:parse_scalar_hash, resolved_name) if options[:scalar_hash]
+          result = self.send(:parse_typed_array, resolved_name, options[:typed_array]) if options[:typed_array]
+          result = options[:default] if (options.key?(:default) && empty_result?(result))
+          raise_bad_type_if_type_mismatch(result, options[:type]) if options[:type] && result
+          result = result.to_s if options[:stringify]
           result
         end
       end
@@ -22,16 +19,13 @@ module Requisite
       def attribute!(name, options={})
         attribute_keys << name
         define_method(name) do
-          result = nil
-          self.send(:around_each_attribute, name) do
-            resolved_name = options[:rename] || name
-            result = self.send(:convert!, resolved_name)
-            result = self.send(:parse_typed_hash, resolved_name, options[:typed_hash]) if options[:typed_hash]
-            result = self.send(:parse_scalar_hash, resolved_name) if options[:scalar_hash]
-            result = self.send(:parse_typed_array, resolved_name, options[:typed_array]) if options[:typed_array]
-            result = result.to_s if options[:stringify]
-            raise_bad_type_if_type_mismatch(result, options[:type]) if options[:type]
-          end
+          resolved_name = options[:rename] || name
+          result = self.send(:convert!, resolved_name)
+          result = self.send(:parse_typed_hash, resolved_name, options[:typed_hash]) if options[:typed_hash]
+          result = self.send(:parse_scalar_hash, resolved_name) if options[:scalar_hash]
+          result = self.send(:parse_typed_array, resolved_name, options[:typed_array]) if options[:typed_array]
+          result = result.to_s if options[:stringify]
+          raise_bad_type_if_type_mismatch(result, options[:type]) if options[:type]
           result
         end
       end
@@ -51,10 +45,6 @@ module Requisite
     end
 
     private
-
-    def around_each_attribute(name)
-      yield
-    end
 
     self.singleton_class.send(:alias_method, :a, :attribute)
     self.singleton_class.send(:alias_method, :a!, :attribute!)

--- a/lib/requisite/version.rb
+++ b/lib/requisite/version.rb
@@ -1,3 +1,3 @@
 module Requisite
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end

--- a/test/requisite/api_user_test.rb
+++ b/test/requisite/api_user_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require 'benchmark'
-
 # Example Object
 class ApiUser < Requisite::ApiModel
 
@@ -18,6 +17,7 @@ class ApiUser < Requisite::ApiModel
     attribute :custom_data, scalar_hash: true, rename: :custom_attributes
     attribute :company
     attribute :companies
+    attribute :api_version, type: Integer
   end
 
   # Ensure that at least one identifier is passed
@@ -26,6 +26,10 @@ class ApiUser < Requisite::ApiModel
     identifier ||= attribute_from_model(:user_id)
     identifier ||= attribute_from_model(:email)
     raise StandardError unless identifier
+  end
+
+  def api_version
+    1
   end
 
   def last_attribute_fetch_time
@@ -89,7 +93,8 @@ module Requisite
         :custom_data => {
           :is_cool => true,
           :logins => 77
-        }
+        },
+        :api_version => 1
       })
       user.name.must_equal('Bob')
     end
@@ -135,7 +140,8 @@ module Requisite
         :custom_data => {
           :different => true
         },
-        :new_attribute => 'hi'
+        :new_attribute => 'hi',
+        :api_version => 1
       })
     end
 
@@ -147,7 +153,8 @@ module Requisite
       user.to_hash.must_equal({
         :user_id => 'abcdef',
         :name => 'Bob',
-        :custom_data => {}
+        :custom_data => {},
+        :api_version => 1
       })
       user.name.must_equal('Bob')
     end
@@ -170,7 +177,8 @@ module Requisite
         :new_session => nil,
         :custom_data => {},
         :company => nil,
-        :companies => nil
+        :companies => nil,
+        :api_version => 1
       })
       user.name.must_equal('Bob')
     end
@@ -182,7 +190,7 @@ module Requisite
 
       user.to_hash(show_nil: true)
 
-      user.attribute_names.must_equal [:id, :user_id, :email, :name, :last_seen_user_agent, :last_request_at, :unsubscribed_from_emails, :update_last_request_at, :new_session, :custom_data, :company, :companies]
+      user.attribute_names.must_equal [:id, :user_id, :email, :name, :created_at, :last_seen_user_agent, :last_request_at, :unsubscribed_from_emails, :update_last_request_at, :new_session, :custom_data, :company, :companies, :api_version]
       user.last_attribute_fetch_time.must_be :>, 0
     end
   end


### PR DESCRIPTION
The previous implementation didnt record attributes that were explicitly implemented on the serializer (rather than passed directly to the underlying model). This ensures that they are correctly instrumented.